### PR TITLE
What i tried with static files

### DIFF
--- a/yw_website/yw_website/apps/website/urls.py
+++ b/yw_website/yw_website/apps/website/urls.py
@@ -1,5 +1,7 @@
+from django.conf.urls.static import static
 from django.urls import include, path
 from rest_framework import routers
+from yw_website.settings import STATIC_ROOT, STATIC_URL
 
 from .views import *
 
@@ -40,3 +42,5 @@ urlpatterns = [
     ###
     path('api/v1/', include(router.urls)),
 ]
+
+# print(static(settings.STATIC_URL, document_root=settings.STATIC_ROOT))

--- a/yw_website/yw_website/settings.py
+++ b/yw_website/yw_website/settings.py
@@ -153,7 +153,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = os.path.join(BASE_DIR, 'yw_website/apps/website/static')
+print(STATIC_ROOT)
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/yw_website/yw_website/urls.py
+++ b/yw_website/yw_website/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path('', include('yw_website.apps.website.urls')),
     path('rest-auth/', include('rest_auth.urls')),
     path('rest-auth/registration/', include('rest_auth.registration.urls'))
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,


### PR DESCRIPTION
# DO NOT MERGE

@clundin55 

This change worked on the project before you moved things around a bit. The main difference I see is that now we have two `urls.py`, one at root, and one in our website app. I tried configuring the static url in both the `urls.py` but it didn't seem to work. 

To confirm the website is properly serving do the following:
1. Run the website on local host 
2. Open the website on google chrome
3. inspect the page
4. click on sources in the top bar of the inspect window
5. you should see a file directory, click on the localhost dropdown, and then on static, and that is what was loaded by the website.
6. From here you can click on css files and look at their contents. If their contents do not match what you have put into the css file in our project, it's still not working correctly.

Some things to note:
* The `STATIC_URL` field is essentially the route that the website accesses to get the static files. There's more going on than that,  but thats my basic understanding
* The `STATIC_ROOT` field is what directory to pull static files from
* the `static` method you see added the the list of routes contained in `urlpatterns` i believe is akin to the `path` method we used to specify valid routes

Some documentation:
https://help.pythonanywhere.com/pages/DjangoStaticFiles/
check out the note at the bottom of this: https://docs.djangoproject.com/en/2.1/intro/tutorial06/
https://docs.djangoproject.com/en/2.1/howto/static-files/
https://docs.djangoproject.com/en/2.1/ref/contrib/staticfiles/
https://docs.djangoproject.com/en/2.1/howto/static-files/deployment/


It might have something to do with using `$python manage.py collectstatic` command since we are now organizing the website by apps (albeit a single app), but I'm not sure. Be aware that the `collectstatic` command seems to generate a bunch of files we may not want included in our project